### PR TITLE
Change the way to get path elements and specialize user

### DIFF
--- a/app/authorization.polar
+++ b/app/authorization.polar
@@ -7,8 +7,8 @@ allow(_user: User, "GET", http_request: Request) if
     http_request.path = "/whoami";
 
 # Allow by path segment
-allow(user, action, http_request: Request) if
-    http_request.path.split("/") = [_, stem, *rest]
+allow(user: User, action, http_request: Request) if
+    [_, stem, *rest] = http_request.path.split("/")
     and allow_by_path(user, action, stem, rest);
 
 ### Expense rules


### PR DESCRIPTION
I have been explained why `http_request.path.split("/") = [_, stem, *rest]` works, but I thought `[_, stem, *rest] = http_request.path.split("/")` would be clearer for me.
I suggest to add a specializer to user in `allow(user, action, http_request: Request)` if  otherwise we can make a request with no authentication and it triggers an exception instead of a 403 http error.